### PR TITLE
Improved promotional cards

### DIFF
--- a/sets/de/promotion.tex
+++ b/sets/de/promotion.tex
@@ -88,6 +88,16 @@
 	\cardstrip
 	\cardbanner{banner/white.png}
 	\cardicon{icons/coin.png}
+	\cardprice{4}
+	\cardtitle{Befestigtes Dorf}
+	Zuerst ziehst du immer eine Karte nach und erhältst +2 Aktionen. Wenn du zu Beginn deiner Aufräumphase die Karte Carcassonne und nicht mehr als eine weitere Aktionskarte im Spiel hast, darfst du dich entscheiden, Carcassonne oben auf deinen Nachziehstapel zu legen oder wie üblich auf den Ablagestapel zu legen. Hast du die Karte Carcassonne genau zweimal im Spiel und ansonsten keine weitere Aktionskarte im Spiel, darfst du eine oder beide Karten Carcassonne auf deinen Nachziehstapel legen.}
+\end{tikzpicture}
+\hspace{-0.6cm}
+\begin{tikzpicture}
+	\card
+	\cardstrip
+	\cardbanner{banner/white.png}
+	\cardicon{icons/coin.png}
 	\cardprice{5}
 	\cardtitle{Gouverneur}
 	\cardcontent{Zuerst erhältst du +1 Aktion. Dann wählst du eine der folgenden Optionen:

--- a/sets/de/promotion.tex
+++ b/sets/de/promotion.tex
@@ -316,4 +316,12 @@
 	*Befehlskarten sind ein neuer Kartentyp, der in den Errata 2019 eingeführt wurde, um zu verhindern, dass manche Fähigkeiten in Endlosschleife gespielt werden können. Befehlskarten sind Emulatoren, die Karten aus dem Vorrat spielen, sie aber dort belassen (bspw.\ \emph{VOGELFREIE} aus \emph{Dark Ages} und der \emph{LEHNSHERR} aus \emph{Empires}).
 	\end{Spacing}}}
 \end{tikzpicture}
+\hspace{-0.6cm}
+\begin{tikzpicture}
+	\card
+	\cardstrip
+	\cardbanner{banner/orange.png}
+	\cardtitle{\scriptsize{Spielvorbereitung}\qquad}
+	Promo-Karten nach Belieben zum Aufbau des Königreiches verwenden.
+\end{tikzpicture}
 \hspace{0.6cm}

--- a/sets/de/promotion.tex
+++ b/sets/de/promotion.tex
@@ -75,7 +75,7 @@
 	\cardbanner{banner/white.png}
 	\cardicon{icons/coin.png}
 	\cardprice{4}
-	\cardtitle{Carcasonne}
+	\cardtitle{Carcassonne}
 	\cardcontent{\emph{Errata:} Der Kartentext ist falsch, es sollte \enquote{Wenn du zu Beginn deiner Aufräumphase nicht mehr als eine weitere Aktionskarte im Spiel hast\dots} statt \enquote{Wenn du zu Beginn deiner Aufräumphase nur noch eine weitere Aktionskarte im Spiel hast\dots} heißen.
 
 	\medskip


### PR DESCRIPTION
I got a full set of promos for christmas, so I needed to make some small changes:

- Fixed the spelling of "Carcassonne" for owners of the original promo
- Created a copy of "Carcassonne", which is now known as "Befestigtes Dorf"
- Added a more or less blank card "Spielvorbereitung" to the promotional set, to be consistent with the other sets. Helps my OCD with organization of the cards in my box. :-)

Warning: I don't have a properly configured LaTeX environment on my machine at the moment, so I wasn't able to test my changes.