### PR TITLE
Add missing \coin in cardcontent of Korsarenschiff

### DIFF
--- a/sets/de/seasideRGG2022.tex
+++ b/sets/de/seasideRGG2022.tex
@@ -253,7 +253,7 @@
 	\cardicon{icons/coin.png}
 	\cardprice{5}
 	\cardtitle{\footnotesize{Korsarenschiff}}
-	\cardcontent{Das entsorgte \emph{SILBER} oder \emph{GOLD} gibt in seinem Zug trotzdem für den Spieler, der es entsorgt.
+	\cardcontent{Das entsorgte \emph{SILBER} oder \emph{GOLD} gibt in seinem Zug trotzdem \coin für den Spieler, der es entsorgt.
 
 	\medskip
 

--- a/sets/de/seasideRGG2022UpdatePack.tex
+++ b/sets/de/seasideRGG2022UpdatePack.tex
@@ -79,7 +79,7 @@
 	\cardicon{icons/coin.png}
 	\cardprice{5}
 	\cardtitle{\footnotesize{Korsarenschiff}}
-	\cardcontent{Das entsorgte \emph{SILBER} oder \emph{GOLD} gibt in seinem Zug trotzdem für den Spieler, der es entsorgt.
+	\cardcontent{Das entsorgte \emph{SILBER} oder \emph{GOLD} gibt in seinem Zug trotzdem \coin für den Spieler, der es entsorgt.
 
 	\medskip
 


### PR DESCRIPTION
I saw that the text of Korsarenschiff was missing a coin. So I added the missing \coin in the cardcontent of seaside 2nd edition and seaside update pack